### PR TITLE
Modernize codebase: fix breaking changes, security issues, and update dependencies

### DIFF
--- a/PyPDFMerger/PyPDFMergerGUI.pyw
+++ b/PyPDFMerger/PyPDFMergerGUI.pyw
@@ -1,204 +1,275 @@
-import os
+"""PyPDFMerger – A simple GUI application for merging PDF files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
 import pypdf
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
+
+# ── PDF logic ─────────────────────────────────────────────────────────────────
+
 class PDF:
     @staticmethod
-    def merge(pdfs, destination, pdfname):
-        merger = pypdf.PdfMerger()
-        result = os.path.join(destination, pdfname)
-        errormsg = ''
+    def merge(pdfs: list[str], output_path: Path) -> None:
+        """Merge *pdfs* into *output_path*.
 
-        if os.path.isfile(result):
-            if language == 'en': errormsg = 'ERROR: Destination file already exists!'
-            elif language == 'es': errormsg = 'ERROR: ¡El archivo de destino ya existe!'
-            raise Exception(errormsg)
+        Raises:
+            FileExistsError: if *output_path* already exists.
+            ValueError: if none of the provided files are readable PDFs.
+        """
+        if output_path.exists():
+            raise FileExistsError(str(output_path))
 
+        writer = pypdf.PdfWriter()
+        valid_count = 0
         for pdf in pdfs:
             if PDF.validate(pdf):
-                try:
-                    merger.append(pdf)
-                except pypdf.errors.EmptyFileError:
-                    continue
+                writer.append(pdf)
+                valid_count += 1
 
-        merger.write(result)
-        merger.close()
+        if valid_count == 0:
+            raise ValueError("No valid PDF files to merge.")
+
+        with open(output_path, "wb") as fh:
+            writer.write(fh)
 
     @staticmethod
-    def validate(pdf):
+    def validate(pdf: str) -> bool:
+        """Return *True* if *pdf* can be opened and read as a valid PDF."""
         try:
-            with open(pdf, 'rb') as file:
-                pypdf.PdfReader(file)
+            with open(pdf, "rb") as fh:
+                pypdf.PdfReader(fh, strict=False)
             return True
-        except (pypdf.errors.PdfReadError, pypdf.errors.EmptyFileError):
+        except (pypdf.errors.PdfReadError, pypdf.errors.EmptyFileError, OSError):
             return False
 
-def select_files():
-    pdf_files = filedialog.askopenfilenames(filetypes=[("PDF files", "*.pdf")])
-    folder_selected = os.path.dirname(pdf_files[0]) if pdf_files else ''
-    folder_var.set(folder_selected)
-    file_listbox.delete(0, tk.END)
-    for pdf in pdf_files:
-        file_listbox.insert(tk.END, pdf)
 
-def merge_pdfs():
-    try:
-        destination = folder_var.get()
-        pdfname = output_name_var.get()
-        
-        files = list(file_listbox.get(0, tk.END))
-        if not files:
-            raise Exception(lang_texts[language]['no_pdfs'])
-        
-        if len(pdfname) == 0:
-            raise Exception(lang_texts[language]['no_name'])
-        
-        if not pdfname.endswith('.pdf'):
-            pdfname += '.pdf'
+# ── Localisation ──────────────────────────────────────────────────────────────
 
-        PDF.merge(files, destination, pdfname)
-        messagebox.showinfo("Success", lang_texts[language]['operation_completed'].format(destination, pdfname))
-    except Exception as e:
-        messagebox.showerror("Error", str(e))
-
-def set_language():
-    global language
-    language = lang_var.get()
-    select_files_btn.config(text=lang_texts[language]['select_files'])
-    merge_pdfs_btn.config(text=lang_texts[language]['merge_pdfs'])
-    move_up_btn.config(text=lang_texts[language]['move_up'])
-    move_down_btn.config(text=lang_texts[language]['move_down'])
-    output_name_label.config(text=lang_texts[language]['output_name'])
-    remove_pdf_btn.config(text=lang_texts[language]['remove_pdf'])
-
-def move_up():
-    try:
-        selected_idx = file_listbox.curselection()[0]
-        if selected_idx > 0:
-            item = file_listbox.get(selected_idx)
-            file_listbox.delete(selected_idx)
-            file_listbox.insert(selected_idx - 1, item)
-            file_listbox.selection_set(selected_idx - 1)
-    except IndexError:
-        pass
-
-def move_down():
-    try:
-        selected_idx = file_listbox.curselection()[0]
-        if selected_idx < file_listbox.size() - 1:
-            item = file_listbox.get(selected_idx)
-            file_listbox.delete(selected_idx)
-            file_listbox.insert(selected_idx + 1, item)
-            file_listbox.selection_set(selected_idx + 1)
-    except IndexError:
-        pass
-
-def remove_pdf():
-    try:
-        selected_idx = file_listbox.curselection()[0]
-        file_listbox.delete(selected_idx)
-    except IndexError:
-        pass
-
-
-
-# Languages
-lang_texts = {
-    'en': {
-        'select_files': 'Select PDFs',
-        'merge_pdfs': 'Merge PDFs',
-        'output_name': 'Output PDF Name:',
-        'operation_completed': 'Operation completed. PDF file saved in "{}" as "{}".',
-        'no_pdfs': 'No PDF files were detected in the selected folder.',
-        'move_up': 'Move up',
-        'move_down': 'Move down',
-        'remove_pdf': 'Remove',
-        'no_name': 'Please set a file name.'
+LANG_TEXTS: dict[str, dict[str, str]] = {
+    "en": {
+        "select_files":        "Select PDFs",
+        "merge_pdfs":          "Merge PDFs",
+        "output_name":         "Output PDF Name:",
+        "operation_completed": "Operation completed. PDF saved in \"{}\" as \"{}\".",
+        "no_pdfs":             "No PDF files have been selected.",
+        "move_up":             "Move up",
+        "move_down":           "Move down",
+        "remove_pdf":          "Remove",
+        "no_name":             "Please enter a file name.",
+        "no_destination":      "No destination folder set. Select at least one PDF first.",
+        "file_exists":         "A file with that name already exists in the destination folder.",
+        "no_valid_pdfs":       "None of the selected files could be read as valid PDFs.",
     },
-    'es': {
-        'select_files': 'Seleccionar PDFs',
-        'merge_pdfs': 'Unir PDFs',
-        'output_name': 'Nombre del PDF de salida:',
-        'operation_completed': 'Operación completada. Archivo PDF guardado en "{}" como "{}".',
-        'no_pdfs': 'No se detectaron archivos PDF en la carpeta seleccionada.',
-        'move_up': 'Mover hacia arriba',
-        'move_down': 'Mover hacia abajo',
-        'remove_pdf': 'Eliminar',
-        'no_name': 'Por favor, establezca un nombre de archivo.'
-    }
+    "es": {
+        "select_files":        "Seleccionar PDFs",
+        "merge_pdfs":          "Unir PDFs",
+        "output_name":         "Nombre del PDF de salida:",
+        "operation_completed": "Operación completada. PDF guardado en \"{}\" como \"{}\".",
+        "no_pdfs":             "No se han seleccionado archivos PDF.",
+        "move_up":             "Mover hacia arriba",
+        "move_down":           "Mover hacia abajo",
+        "remove_pdf":          "Eliminar",
+        "no_name":             "Por favor, introduzca un nombre de archivo.",
+        "no_destination":      "No se ha establecido carpeta de destino. Seleccione al menos un PDF primero.",
+        "file_exists":         "Ya existe un archivo con ese nombre en la carpeta de destino.",
+        "no_valid_pdfs":       "Ninguno de los archivos seleccionados pudo leerse como PDF válido.",
+    },
 }
 
 
+# ── GUI ───────────────────────────────────────────────────────────────────────
 
-# GUI
-# Create the main application window
-app = tk.Tk()
-app.title("PDF Merger")
-app.geometry("600x400")
-app.minsize(600, 400)
+class PDFMergerApp:
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("PDF Merger")
+        self.root.geometry("600x400")
+        self.root.minsize(600, 400)
 
-folder_var = tk.StringVar()
-output_name_var = tk.StringVar()
+        self.folder_var = tk.StringVar()
+        self.output_name_var = tk.StringVar()
+        self.lang_var = tk.StringVar(value="en")
 
-lang_var = tk.StringVar(value='en')
-language = lang_var.get()
+        self._build_ui()
 
-# Configure grid columns and rows
-app.grid_columnconfigure(0, weight=1)
-app.grid_columnconfigure(1, weight=1)
-app.grid_columnconfigure(2, weight=1)
-app.grid_rowconfigure(2, weight=1) # Configure the row for the Listbox to expand vertically
+    @property
+    def language(self) -> str:
+        return self.lang_var.get()
 
-# Create and place the language frame
-frame_lang = tk.Frame(app)
-frame_lang.grid(row=0, column=0, padx=10, pady=10, sticky="w")
+    @property
+    def t(self) -> dict[str, str]:
+        """Return the translation dictionary for the current language."""
+        return LANG_TEXTS[self.language]
 
-tk.Label(frame_lang, text="Language:").pack(side=tk.LEFT, padx=5, pady=10)
-tk.Radiobutton(frame_lang, text="English", variable=lang_var, value='en', command=set_language).pack(side=tk.LEFT, padx=5, pady=10)
-tk.Radiobutton(frame_lang, text="Español", variable=lang_var, value='es', command=set_language).pack(side=tk.LEFT, padx=5, pady=10)
+    # ── UI construction ────────────────────────────────────────────────────
 
-# Create and place the select files button
-select_files_btn = tk.Button(app, text=lang_texts[language]['select_files'], command=select_files)
-select_files_btn.grid(row=1, column=0, columnspan=3, padx=10, pady=10, sticky="ew")
+    def _build_ui(self) -> None:
+        root = self.root
+        root.grid_columnconfigure(0, weight=1)
+        root.grid_columnconfigure(1, weight=1)
+        root.grid_columnconfigure(2, weight=1)
+        root.grid_rowconfigure(2, weight=1)
 
-# Create and place the frame containing the listbox and scrollbar
-frame = tk.Frame(app)
-frame.grid(row=2, column=0, columnspan=3, padx=10, pady=10, sticky="nsew")
+        # Language selector
+        frame_lang = tk.Frame(root)
+        frame_lang.grid(row=0, column=0, padx=10, pady=10, sticky="w")
+        tk.Label(frame_lang, text="Language:").pack(side=tk.LEFT, padx=5, pady=10)
+        tk.Radiobutton(
+            frame_lang, text="English", variable=self.lang_var,
+            value="en", command=self._on_language_change,
+        ).pack(side=tk.LEFT, padx=5, pady=10)
+        tk.Radiobutton(
+            frame_lang, text="Español", variable=self.lang_var,
+            value="es", command=self._on_language_change,
+        ).pack(side=tk.LEFT, padx=5, pady=10)
 
-scrollbar = tk.Scrollbar(frame, orient="vertical")
-scrollbar.pack(side="right", fill="y")
+        # Select files button
+        self.select_files_btn = tk.Button(
+            root, text=self.t["select_files"], command=self._select_files,
+        )
+        self.select_files_btn.grid(
+            row=1, column=0, columnspan=3, padx=10, pady=10, sticky="ew",
+        )
 
-file_listbox = tk.Listbox(frame, yscrollcommand=scrollbar.set)
-file_listbox.pack(side="left", fill="both", expand=True)
-scrollbar.config(command=file_listbox.yview)
+        # Listbox + scrollbar
+        frame_list = tk.Frame(root)
+        frame_list.grid(row=2, column=0, columnspan=3, padx=10, pady=10, sticky="nsew")
+        scrollbar = tk.Scrollbar(frame_list, orient="vertical")
+        scrollbar.pack(side="right", fill="y")
+        self.file_listbox = tk.Listbox(frame_list, yscrollcommand=scrollbar.set)
+        self.file_listbox.pack(side="left", fill="both", expand=True)
+        scrollbar.config(command=self.file_listbox.yview)
 
-# Create a frame to hold the buttons with equal width
-button_frame = tk.Frame(app)
-button_frame.grid(row=3, column=0, columnspan=3, padx=10, pady=10, sticky="ew")
+        # List-management buttons
+        btn_frame = tk.Frame(root)
+        btn_frame.grid(row=3, column=0, columnspan=3, padx=10, pady=10, sticky="ew")
+        btn_width = 15
+        self.move_up_btn = tk.Button(
+            btn_frame, text=self.t["move_up"], command=self._move_up, width=btn_width,
+        )
+        self.move_up_btn.pack(side=tk.LEFT, padx=5, pady=10, expand=True, fill=tk.X)
+        self.move_down_btn = tk.Button(
+            btn_frame, text=self.t["move_down"], command=self._move_down, width=btn_width,
+        )
+        self.move_down_btn.pack(side=tk.LEFT, padx=5, pady=10, expand=True, fill=tk.X)
+        self.remove_pdf_btn = tk.Button(
+            btn_frame, text=self.t["remove_pdf"], command=self._remove_pdf, width=btn_width,
+        )
+        self.remove_pdf_btn.pack(side=tk.LEFT, padx=5, pady=10, expand=True, fill=tk.X)
 
-# Create buttons with a fixed width and pack them in the frame
-button_width = 15
+        # Output name
+        self.output_name_label = tk.Label(root, text=self.t["output_name"])
+        self.output_name_label.grid(row=4, column=0, padx=10, pady=10, sticky="e")
+        tk.Entry(root, textvariable=self.output_name_var).grid(
+            row=4, column=1, columnspan=2, padx=10, pady=10, sticky="ew",
+        )
 
-move_up_btn = tk.Button(button_frame, text=lang_texts[language]['move_up'], command=move_up, width=button_width)
-move_up_btn.pack(side=tk.LEFT, padx=5, pady=10, expand=True, fill=tk.X)
+        # Merge button
+        self.merge_pdfs_btn = tk.Button(
+            root, text=self.t["merge_pdfs"], command=self._merge_pdfs,
+        )
+        self.merge_pdfs_btn.grid(
+            row=5, column=0, columnspan=3, padx=10, pady=10, sticky="ew",
+        )
 
-move_down_btn = tk.Button(button_frame, text=lang_texts[language]['move_down'], command=move_down, width=button_width)
-move_down_btn.pack(side=tk.LEFT, padx=5, pady=10, expand=True, fill=tk.X)
+    # ── Event handlers ─────────────────────────────────────────────────────
 
-remove_pdf_btn = tk.Button(button_frame, text=lang_texts[language]['remove_pdf'], command=remove_pdf, width=button_width)
-remove_pdf_btn.pack(side=tk.LEFT, padx=5, pady=10, expand=True, fill=tk.X)
+    def _on_language_change(self) -> None:
+        self.select_files_btn.config(text=self.t["select_files"])
+        self.merge_pdfs_btn.config(text=self.t["merge_pdfs"])
+        self.move_up_btn.config(text=self.t["move_up"])
+        self.move_down_btn.config(text=self.t["move_down"])
+        self.output_name_label.config(text=self.t["output_name"])
+        self.remove_pdf_btn.config(text=self.t["remove_pdf"])
 
-# Create and place the output name label and entry
-output_name_label = tk.Label(app, text=lang_texts[language]['output_name'])
-output_name_label.grid(row=4, column=0, padx=10, pady=10, sticky="e")
+    def _select_files(self) -> None:
+        pdf_files = filedialog.askopenfilenames(filetypes=[("PDF files", "*.pdf")])
+        if not pdf_files:
+            return  # user cancelled the dialog
+        self.folder_var.set(str(Path(pdf_files[0]).parent))
+        self.file_listbox.delete(0, tk.END)
+        for pdf in pdf_files:
+            self.file_listbox.insert(tk.END, pdf)
 
-output_name_entry = tk.Entry(app, textvariable=output_name_var)
-output_name_entry.grid(row=4, column=1, columnspan=2, padx=10, pady=10, sticky="ew")
+    def _merge_pdfs(self) -> None:
+        destination = self.folder_var.get()
+        raw_name = self.output_name_var.get().strip()
+        files = list(self.file_listbox.get(0, tk.END))
 
-# Create and place the merge PDFs button
-merge_pdfs_btn = tk.Button(app, text=lang_texts[language]['merge_pdfs'], command=merge_pdfs)
-merge_pdfs_btn.grid(row=5, column=0, columnspan=3, padx=10, pady=10, sticky="ew")
+        if not files:
+            messagebox.showerror("Error", self.t["no_pdfs"])
+            return
 
-# Run the application
-app.mainloop()
+        if not raw_name:
+            messagebox.showerror("Error", self.t["no_name"])
+            return
+
+        # Strip any path components to prevent directory traversal attacks
+        pdfname = Path(raw_name).name
+        if not pdfname:
+            messagebox.showerror("Error", self.t["no_name"])
+            return
+        if not pdfname.lower().endswith(".pdf"):
+            pdfname += ".pdf"
+
+        if not destination:
+            messagebox.showerror("Error", self.t["no_destination"])
+            return
+
+        output_path = Path(destination) / pdfname
+
+        try:
+            PDF.merge(files, output_path)
+        except FileExistsError:
+            messagebox.showerror("Error", self.t["file_exists"])
+            return
+        except ValueError:
+            messagebox.showerror("Error", self.t["no_valid_pdfs"])
+            return
+        except OSError as exc:
+            messagebox.showerror("Error", str(exc))
+            return
+
+        messagebox.showinfo(
+            "Success",
+            self.t["operation_completed"].format(destination, pdfname),
+        )
+
+    def _move_up(self) -> None:
+        try:
+            idx = self.file_listbox.curselection()[0]
+            if idx > 0:
+                item = self.file_listbox.get(idx)
+                self.file_listbox.delete(idx)
+                self.file_listbox.insert(idx - 1, item)
+                self.file_listbox.selection_set(idx - 1)
+        except IndexError:
+            pass
+
+    def _move_down(self) -> None:
+        try:
+            idx = self.file_listbox.curselection()[0]
+            if idx < self.file_listbox.size() - 1:
+                item = self.file_listbox.get(idx)
+                self.file_listbox.delete(idx)
+                self.file_listbox.insert(idx + 1, item)
+                self.file_listbox.selection_set(idx + 1)
+        except IndexError:
+            pass
+
+    def _remove_pdf(self) -> None:
+        try:
+            idx = self.file_listbox.curselection()[0]
+            self.file_listbox.delete(idx)
+        except IndexError:
+            pass
+
+
+if __name__ == "__main__":
+    app = tk.Tk()
+    PDFMergerApp(app)
+    app.mainloop()

--- a/PyPDFMerger/config.py
+++ b/PyPDFMerger/config.py
@@ -1,2 +1,1 @@
-PDFDir = r'pdfs'
-PDFResultName = r'PDFMerged.pdf'
+# Reserved for future application configuration.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cx_Freeze==7.1.0
-pypdf==6.0.0
+pypdf>=6.0.0
+cx_Freeze>=7.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
 from cx_Freeze import setup, Executable
 
+build_exe_options = {
+    "excludes": ["test", "unittest"],
+}
+
 setup(
-    name = "PyPDFMerger",
-    version = "1.0",
-    description = "A PDF Merger GUI",
-    executables = [Executable("PyPDFMerger/PyPDFMergerGUI.pyw", base="Win32GUI")]
+    name="PyPDFMerger",
+    version="1.0",
+    description="A PDF Merger GUI",
+    options={"build_exe": build_exe_options},
+    executables=[
+        Executable(
+            "PyPDFMerger/PyPDFMergerGUI.pyw",
+            base="Win32GUI",
+            target_name="PyPDFMerger",
+        )
+    ],
 )


### PR DESCRIPTION
- Fix broken pypdf.PdfMerger usage (removed in pypdf 5+); replace with
  pypdf.PdfWriter().append() throughout PDF.merge()
- Fix crash in select_files() when user cancels the file dialog
  (was indexing into an empty tuple with pdf_files[0])
- Fix directory traversal vulnerability: sanitize user-supplied output
  filename with Path(raw_name).name before joining with destination
- Refactor flat module-level globals into PDFMergerApp class, eliminating
  the global `language` variable and coupling between PDF logic and i18n
- Decouple PDF class from language: it now raises standard Python
  exceptions (FileExistsError, ValueError) that the GUI layer translates
- Add missing error messages: no_destination, file_exists, no_valid_pdfs
  in both English and Spanish; ensure en/es key sets are identical
- Add guard for zero-valid-PDFs case: raises ValueError before attempting
  to write an empty output file
- Replace os.path usage with pathlib.Path throughout
- Add from __future__ import annotations and type hints for clarity
- Add if __name__ == "__main__": guard for the entry point
- Update requirements.txt: relax pins to >= minimums so users receive
  security/bug-fix updates (pypdf>=6.0.0, cx_Freeze>=7.1.0)
- Modernize setup.py: add build_exe_options dict, target_name for the
  Executable, consistent with cx_Freeze 7.x API
- Remove dead code from config.py (PDFDir, PDFResultName were never used)

https://claude.ai/code/session_01FoThwbdrWp9fqZtxrw2gcQ