### PR TITLE
Add PDF split functionality with three split modes

### DIFF
--- a/PyPDFMerger/PyPDFMergerGUI.pyw
+++ b/PyPDFMerger/PyPDFMergerGUI.pyw
@@ -1,8 +1,10 @@
-"""PyPDFMerger – A simple GUI application for merging PDF files."""
+"""PyPDFMerger – A simple GUI application for merging and splitting PDF files."""
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
+import re
 
 import pypdf
 import tkinter as tk
@@ -38,12 +40,124 @@ class PDF:
                     skipped.append(pdf)
 
             if valid_count == 0:
-                raise ValueError("No valid PDF files to merge.")
+                raise ValueError("no_valid_pdfs")
 
             with open(output_path, "wb") as fh:
                 writer.write(fh)
 
         return skipped
+
+    @staticmethod
+    def split_by_ranges(
+        source_pdf: str,
+        output_dir: Path,
+        output_stem: str,
+        ranges_spec: str,
+    ) -> list[Path]:
+        """Split *source_pdf* into one file per page range expression."""
+        reader = PDF._open_reader(source_pdf)
+        total_pages = len(reader.pages)
+        page_ranges = PDF._parse_page_ranges(ranges_spec, total_pages)
+
+        output_paths: list[Path] = []
+        for start, end in page_ranges:
+            if start == end:
+                filename = f"{output_stem}_page_{start}.pdf"
+            else:
+                filename = f"{output_stem}_pages_{start}-{end}.pdf"
+            output_paths.append(output_dir / filename)
+
+        PDF._ensure_outputs_do_not_exist(output_paths)
+        PDF._write_ranges(reader, page_ranges, output_paths)
+        return output_paths
+
+    @staticmethod
+    def split_every_n(
+        source_pdf: str,
+        output_dir: Path,
+        output_stem: str,
+        chunk_size: int,
+    ) -> list[Path]:
+        """Split *source_pdf* into chunks of *chunk_size* pages."""
+        if chunk_size <= 0:
+            raise ValueError("invalid_chunk_size")
+
+        reader = PDF._open_reader(source_pdf)
+        total_pages = len(reader.pages)
+        if total_pages == 0:
+            raise ValueError("invalid_source_pdf")
+
+        page_ranges: list[tuple[int, int]] = []
+        start = 1
+        while start <= total_pages:
+            end = min(start + chunk_size - 1, total_pages)
+            page_ranges.append((start, end))
+            start = end + 1
+
+        output_paths = []
+        for index, (range_start, range_end) in enumerate(page_ranges, start=1):
+            filename = (
+                f"{output_stem}_part_{index:02d}_pages_{range_start}-{range_end}.pdf"
+            )
+            output_paths.append(output_dir / filename)
+
+        PDF._ensure_outputs_do_not_exist(output_paths)
+        PDF._write_ranges(reader, page_ranges, output_paths)
+        return output_paths
+
+    @staticmethod
+    def split_by_bookmarks(
+        source_pdf: str,
+        output_dir: Path,
+        output_stem: str,
+    ) -> list[Path]:
+        """Split *source_pdf* by top-level bookmarks / sections."""
+        reader = PDF._open_reader(source_pdf)
+        total_pages = len(reader.pages)
+
+        sections = PDF._collect_bookmark_sections(reader)
+        if not sections:
+            raise ValueError("no_bookmarks_found")
+
+        page_ranges: list[tuple[int, int]] = []
+        output_paths: list[Path] = []
+        for index, (start_page_index, title) in enumerate(sections, start=1):
+            if index < len(sections):
+                end_page_index = sections[index][0] - 1
+            else:
+                end_page_index = total_pages - 1
+
+            if end_page_index < start_page_index:
+                continue
+
+            # Convert to one-based ranges for naming and write logic.
+            start_page = start_page_index + 1
+            end_page = end_page_index + 1
+            page_ranges.append((start_page, end_page))
+
+            safe_title = PDF._sanitize_component(title) or f"section_{index:02d}"
+            filename = f"{output_stem}_{index:02d}_{safe_title}.pdf"
+            output_paths.append(output_dir / filename)
+
+        if not output_paths:
+            raise ValueError("no_bookmarks_found")
+
+        PDF._ensure_outputs_do_not_exist(output_paths)
+        PDF._write_ranges(reader, page_ranges, output_paths)
+        return output_paths
+
+    @staticmethod
+    def build_output_stem(raw_name: str, fallback: str) -> str:
+        """Build a safe output stem from user input and fallback."""
+        name = raw_name.strip()
+        if name.lower().endswith(".pdf"):
+            name = name[:-4]
+
+        sanitized = PDF._sanitize_component(name)
+        if sanitized:
+            return sanitized
+        fallback_sanitized = PDF._sanitize_component(fallback)
+        return fallback_sanitized or "output"
 
     @staticmethod
     def validate(pdf: str) -> bool:
@@ -55,47 +169,228 @@ class PDF:
         except (pypdf.errors.PdfReadError, pypdf.errors.EmptyFileError, OSError):
             return False
 
+    @staticmethod
+    def _open_reader(pdf: str) -> pypdf.PdfReader:
+        if not PDF.validate(pdf):
+            raise ValueError("invalid_source_pdf")
+        data = Path(pdf).read_bytes()
+        reader = pypdf.PdfReader(io.BytesIO(data), strict=False)
+        _ = len(reader.pages)
+        return reader
+
+    @staticmethod
+    def _parse_page_ranges(spec: str, total_pages: int) -> list[tuple[int, int]]:
+        if total_pages <= 0:
+            raise ValueError("invalid_source_pdf")
+
+        raw_spec = spec.strip()
+        if not raw_spec:
+            raise ValueError("invalid_page_ranges")
+
+        parsed: list[tuple[int, int]] = []
+        for token in raw_spec.split(","):
+            item = token.strip()
+            if not item:
+                raise ValueError("invalid_page_ranges")
+
+            if "-" in item:
+                left, right = item.split("-", 1)
+                if not left.strip().isdigit() or not right.strip().isdigit():
+                    raise ValueError("invalid_page_ranges")
+                start = int(left.strip())
+                end = int(right.strip())
+            else:
+                if not item.isdigit():
+                    raise ValueError("invalid_page_ranges")
+                start = end = int(item)
+
+            if start < 1 or end < 1 or start > end or end > total_pages:
+                raise ValueError("invalid_page_ranges")
+            parsed.append((start, end))
+
+        if not parsed:
+            raise ValueError("invalid_page_ranges")
+        return parsed
+
+    @staticmethod
+    def _bookmark_page_index(reader: pypdf.PdfReader, item) -> int | None:
+        try:
+            return reader.get_destination_page_number(item)
+        except Exception:
+            pass
+
+        try:
+            page_obj = getattr(item, "page", None)
+            if page_obj is not None:
+                return reader.get_page_number(page_obj)
+        except Exception:
+            return None
+        return None
+
+    @staticmethod
+    def _bookmark_title(item, fallback: str = "Section") -> str:
+        title = getattr(item, "title", None)
+        if title:
+            return str(title)
+        if isinstance(item, dict):
+            raw = item.get("/Title") or item.get("title")
+            if raw:
+                return str(raw)
+        return fallback
+
+    @staticmethod
+    def _collect_bookmark_sections(reader: pypdf.PdfReader) -> list[tuple[int, str]]:
+        try:
+            outline = reader.outline
+        except Exception:
+            return []
+
+        items = outline if isinstance(outline, list) else [outline]
+        collected: list[tuple[int, str]] = []
+        for item in items:
+            # Nested lists are child bookmarks for previous top-level entry.
+            if isinstance(item, list):
+                continue
+            page_index = PDF._bookmark_page_index(reader, item)
+            if page_index is None:
+                continue
+            if page_index < 0 or page_index >= len(reader.pages):
+                continue
+            collected.append((page_index, PDF._bookmark_title(item)))
+
+        if not collected:
+            return []
+
+        # Sort and de-duplicate by starting page, preserving first title.
+        ordered = sorted(collected, key=lambda entry: entry[0])
+        unique: list[tuple[int, str]] = []
+        seen_pages: set[int] = set()
+        for page_index, title in ordered:
+            if page_index in seen_pages:
+                continue
+            seen_pages.add(page_index)
+            unique.append((page_index, title))
+
+        if unique and unique[0][0] > 0:
+            unique.insert(0, (0, "Start"))
+        return unique
+
+    @staticmethod
+    def _sanitize_component(value: str) -> str:
+        cleaned = re.sub(r"[<>:\"/\\|?*\x00-\x1f]", "_", value)
+        cleaned = re.sub(r"\s+", "_", cleaned).strip("._ ")
+        return cleaned[:80]
+
+    @staticmethod
+    def _ensure_outputs_do_not_exist(paths: list[Path]) -> None:
+        for path in paths:
+            if path.exists():
+                raise FileExistsError(str(path))
+
+    @staticmethod
+    def _write_ranges(
+        reader: pypdf.PdfReader,
+        page_ranges: list[tuple[int, int]],
+        output_paths: list[Path],
+    ) -> None:
+        for (start, end), output_path in zip(page_ranges, output_paths):
+            writer = pypdf.PdfWriter()
+            for page_index in range(start - 1, end):
+                writer.add_page(reader.pages[page_index])
+            with open(output_path, "wb") as fh:
+                writer.write(fh)
+
 
 # ── Localisation ──────────────────────────────────────────────────────────────
 
 LANG_TEXTS: dict[str, dict[str, str]] = {
     "en": {
-        "app_subtitle":        "Combine multiple PDFs into one",
-        "select_files":        "Select PDF Files",
-        "merge_pdfs":          "Merge PDFs",
-        "output_name":         "Output file name",
-        "operation_completed": "PDF saved successfully in \"{}\" as \"{}\".",
-        "no_pdfs":             "No PDF files have been selected.",
-        "move_up":             "\u2191  Move Up",
-        "move_down":           "\u2193  Move Down",
-        "remove_pdf":          "\u00d7  Remove",
-        "no_name":             "Please enter a file name.",
-        "no_destination":      "No destination folder set. Select at least one PDF first.",
-        "file_exists":         "A file with that name already exists in the destination folder.",
-        "no_valid_pdfs":       "None of the selected files could be read as valid PDFs.",
-        "some_pdfs_skipped":   "Some files were skipped (invalid PDFs):\n\n{}",
-        "files_selected":      "{} file(s) selected",
-        "no_files":            "No files selected",
-        "destination":         "Destination:",
+        "app_title":               "PDF Merger",
+        "app_subtitle_merge":      "Combine multiple PDFs into one",
+        "app_subtitle_split":      "Split one PDF into multiple files",
+        "language_label":          "Language:",
+        "operation_label":         "Mode:",
+        "mode_merge":              "Merge",
+        "mode_split":              "Split",
+        "select_files":            "Select PDF Files",
+        "select_single_file":      "Select PDF File",
+        "merge_pdfs":              "Merge PDFs",
+        "split_pdfs":              "Split PDF",
+        "output_name":             "Output file name",
+        "output_prefix":           "Output prefix (optional)",
+        "split_method":            "Split method",
+        "split_by_ranges":         "Page range(s)",
+        "split_every_n":           "Every N pages",
+        "split_by_bookmarks":      "Bookmarks / sections",
+        "ranges_label":            "Ranges (e.g. 1-3, 5, 8-10)",
+        "every_n_label":           "Pages per file",
+        "split_hint_ranges":       "Create one output file per listed range.",
+        "split_hint_every_n":      "Split sequentially in fixed-size page chunks.",
+        "split_hint_bookmarks":    "Use top-level bookmarks as section boundaries.",
+        "operation_completed":     "PDF saved successfully in \"{}\" as \"{}\".",
+        "split_completed":         "{} file(s) created successfully in \"{}\".",
+        "no_pdfs":                 "No PDF files have been selected.",
+        "split_requires_one_pdf":  "Please select exactly one PDF to split.",
+        "move_up":                 "\u2191  Move Up",
+        "move_down":               "\u2193  Move Down",
+        "remove_pdf":              "\u00d7  Remove",
+        "no_name":                 "Please enter a file name.",
+        "no_destination":          "No destination folder set. Select a PDF first.",
+        "file_exists":             "A file with that name already exists in the destination folder.",
+        "split_file_exists":       "One output file already exists:\n\n{}",
+        "no_valid_pdfs":           "None of the selected files could be read as valid PDFs.",
+        "invalid_source_pdf":      "The selected PDF could not be read as a valid PDF.",
+        "invalid_page_ranges":     "Invalid page ranges. Use values like: 1-3,5,8-10.",
+        "invalid_chunk_size":      "Pages-per-file must be a whole number greater than 0.",
+        "no_bookmarks_found":      "No usable bookmarks were found to split this PDF.",
+        "some_pdfs_skipped":       "Some files were skipped (invalid PDFs):\n\n{}",
+        "files_selected":          "{} file(s) selected",
+        "no_files":                "No files selected",
+        "destination":             "Destination:",
     },
     "es": {
-        "app_subtitle":        "Combina m\u00faltiples PDFs en uno",
-        "select_files":        "Seleccionar PDFs",
-        "merge_pdfs":          "Unir PDFs",
-        "output_name":         "Nombre del archivo de salida",
-        "operation_completed": "PDF guardado exitosamente en \"{}\" como \"{}\".",
-        "no_pdfs":             "No se han seleccionado archivos PDF.",
-        "move_up":             "\u2191  Subir",
-        "move_down":           "\u2193  Bajar",
-        "remove_pdf":          "\u00d7  Eliminar",
-        "no_name":             "Por favor, introduzca un nombre de archivo.",
-        "no_destination":      "No se ha establecido carpeta de destino. Seleccione al menos un PDF primero.",
-        "file_exists":         "Ya existe un archivo con ese nombre en la carpeta de destino.",
-        "no_valid_pdfs":       "Ninguno de los archivos seleccionados pudo leerse como PDF v\u00e1lido.",
-        "some_pdfs_skipped":   "Algunos archivos fueron omitidos (PDFs inv\u00e1lidos):\n\n{}",
-        "files_selected":      "{} archivo(s) seleccionado(s)",
-        "no_files":            "Sin archivos seleccionados",
-        "destination":         "Destino:",
+        "app_title":               "PDF Merger",
+        "app_subtitle_merge":      "Combina m\u00faltiples PDFs en uno",
+        "app_subtitle_split":      "Divide un PDF en varios archivos",
+        "language_label":          "Idioma:",
+        "operation_label":         "Modo:",
+        "mode_merge":              "Unir",
+        "mode_split":              "Dividir",
+        "select_files":            "Seleccionar PDFs",
+        "select_single_file":      "Seleccionar PDF",
+        "merge_pdfs":              "Unir PDFs",
+        "split_pdfs":              "Dividir PDF",
+        "output_name":             "Nombre del archivo de salida",
+        "output_prefix":           "Prefijo de salida (opcional)",
+        "split_method":            "M\u00e9todo de divisi\u00f3n",
+        "split_by_ranges":         "Rango(s) de p\u00e1ginas",
+        "split_every_n":           "Cada N p\u00e1ginas",
+        "split_by_bookmarks":      "Marcadores / secciones",
+        "ranges_label":            "Rangos (ej. 1-3, 5, 8-10)",
+        "every_n_label":           "P\u00e1ginas por archivo",
+        "split_hint_ranges":       "Crea un archivo por cada rango indicado.",
+        "split_hint_every_n":      "Divide de forma secuencial en bloques fijos.",
+        "split_hint_bookmarks":    "Usa marcadores de primer nivel como secciones.",
+        "operation_completed":     "PDF guardado exitosamente en \"{}\" como \"{}\".",
+        "split_completed":         "{} archivo(s) creado(s) exitosamente en \"{}\".",
+        "no_pdfs":                 "No se han seleccionado archivos PDF.",
+        "split_requires_one_pdf":  "Seleccione exactamente un PDF para dividir.",
+        "move_up":                 "\u2191  Subir",
+        "move_down":               "\u2193  Bajar",
+        "remove_pdf":              "\u00d7  Eliminar",
+        "no_name":                 "Por favor, introduzca un nombre de archivo.",
+        "no_destination":          "No se ha establecido carpeta de destino. Seleccione un PDF primero.",
+        "file_exists":             "Ya existe un archivo con ese nombre en la carpeta de destino.",
+        "split_file_exists":       "Uno de los archivos de salida ya existe:\n\n{}",
+        "no_valid_pdfs":           "Ninguno de los archivos seleccionados pudo leerse como PDF v\u00e1lido.",
+        "invalid_source_pdf":      "El PDF seleccionado no pudo leerse como un PDF v\u00e1lido.",
+        "invalid_page_ranges":     "Rangos de p\u00e1gina inv\u00e1lidos. Use algo como: 1-3,5,8-10.",
+        "invalid_chunk_size":      "P\u00e1ginas por archivo debe ser un n\u00famero mayor que 0.",
+        "no_bookmarks_found":      "No se encontraron marcadores v\u00e1lidos para dividir este PDF.",
+        "some_pdfs_skipped":       "Algunos archivos fueron omitidos (PDFs inv\u00e1lidos):\n\n{}",
+        "files_selected":          "{} archivo(s) seleccionado(s)",
+        "no_files":                "Sin archivos seleccionados",
+        "destination":             "Destino:",
     },
 }
 
@@ -128,8 +423,8 @@ class PDFMergerApp:
     def __init__(self, root: tk.Tk) -> None:
         self.root = root
         self.root.title("PDF Merger")
-        self.root.geometry("700x560")
-        self.root.minsize(580, 480)
+        self.root.geometry("760x680")
+        self.root.minsize(620, 560)
         self.root.configure(bg=THEME["bg"])
 
         # Full paths tracked separately from listbox display names
@@ -138,6 +433,10 @@ class PDFMergerApp:
         self.folder_var = tk.StringVar()
         self.output_name_var = tk.StringVar()
         self.lang_var = tk.StringVar(value="en")
+        self.operation_var = tk.StringVar(value="merge")
+        self.split_mode_var = tk.StringVar(value="range")
+        self.split_ranges_var = tk.StringVar()
+        self.split_every_n_var = tk.StringVar(value="1")
 
         self._setup_fonts()
         self._build_ui()
@@ -150,17 +449,25 @@ class PDFMergerApp:
         available = set(tkfont.families())
         family = next((f for f in preferred_families if f in available), "TkDefaultFont")
 
-        self.font_heading  = tkfont.Font(family=family, size=15, weight="bold")
+        self.font_heading = tkfont.Font(family=family, size=15, weight="bold")
         self.font_subtitle = tkfont.Font(family=family, size=9)
-        self.font_label    = tkfont.Font(family=family, size=10)
-        self.font_btn      = tkfont.Font(family=family, size=10, weight="bold")
-        self.font_btn_sm   = tkfont.Font(family=family, size=9)
-        self.font_list     = tkfont.Font(family=family, size=9)
-        self.font_status   = tkfont.Font(family=family, size=8)
+        self.font_label = tkfont.Font(family=family, size=10)
+        self.font_btn = tkfont.Font(family=family, size=10, weight="bold")
+        self.font_btn_sm = tkfont.Font(family=family, size=9)
+        self.font_list = tkfont.Font(family=family, size=9)
+        self.font_status = tkfont.Font(family=family, size=8)
 
     @property
     def language(self) -> str:
         return self.lang_var.get()
+
+    @property
+    def operation(self) -> str:
+        return self.operation_var.get()
+
+    @property
+    def split_mode(self) -> str:
+        return self.split_mode_var.get()
 
     @property
     def t(self) -> dict[str, str]:
@@ -218,25 +525,27 @@ class PDFMergerApp:
         title_row = tk.Frame(header_inner, bg=THEME["surface"])
         title_row.pack(fill="x")
 
-        tk.Label(
+        self.title_label = tk.Label(
             title_row,
-            text="PDF Merger",
+            text=self.t["app_title"],
             bg=THEME["surface"],
             fg=THEME["text"],
             font=self.font_heading,
-        ).pack(side="left")
+        )
+        self.title_label.pack(side="left")
 
         # Language toggle buttons (right side of header)
         lang_frame = tk.Frame(title_row, bg=THEME["surface"])
         lang_frame.pack(side="right", anchor="center")
 
-        tk.Label(
+        self.language_label = tk.Label(
             lang_frame,
-            text="Language:",
+            text=self.t["language_label"],
             bg=THEME["surface"],
             fg=THEME["text_secondary"],
             font=self.font_status,
-        ).pack(side="left", padx=(0, 6))
+        )
+        self.language_label.pack(side="left", padx=(0, 6))
 
         self._lang_en_btn = tk.Button(
             lang_frame, text="EN",
@@ -258,7 +567,7 @@ class PDFMergerApp:
 
         self.subtitle_label = tk.Label(
             header_inner,
-            text=self.t["app_subtitle"],
+            text=self.t["app_subtitle_merge"],
             bg=THEME["surface"],
             fg=THEME["text_secondary"],
             font=self.font_subtitle,
@@ -270,6 +579,61 @@ class PDFMergerApp:
         # ── Body ────────────────────────────────────────────────────────────
         body = tk.Frame(root, bg=THEME["bg"])
         body.pack(fill="both", expand=True, padx=20, pady=16)
+
+        # Mode switch
+        mode_card = tk.Frame(
+            body,
+            bg=THEME["surface"],
+            highlightbackground=THEME["border"],
+            highlightthickness=1,
+        )
+        mode_card.pack(fill="x", pady=(0, 10))
+
+        mode_inner = tk.Frame(mode_card, bg=THEME["surface"])
+        mode_inner.pack(fill="x", padx=12, pady=10)
+
+        self.operation_label = tk.Label(
+            mode_inner,
+            text=self.t["operation_label"],
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            font=self.font_label,
+        )
+        self.operation_label.pack(side="left")
+
+        self.mode_merge_rb = tk.Radiobutton(
+            mode_inner,
+            text=self.t["mode_merge"],
+            variable=self.operation_var,
+            value="merge",
+            command=self._on_operation_change,
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            selectcolor=THEME["surface"],
+            activebackground=THEME["surface"],
+            activeforeground=THEME["text"],
+            font=self.font_btn_sm,
+            padx=8,
+            highlightthickness=0,
+        )
+        self.mode_merge_rb.pack(side="left", padx=(8, 0))
+
+        self.mode_split_rb = tk.Radiobutton(
+            mode_inner,
+            text=self.t["mode_split"],
+            variable=self.operation_var,
+            value="split",
+            command=self._on_operation_change,
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            selectcolor=THEME["surface"],
+            activebackground=THEME["surface"],
+            activeforeground=THEME["text"],
+            font=self.font_btn_sm,
+            padx=8,
+            highlightthickness=0,
+        )
+        self.mode_split_rb.pack(side="left", padx=(8, 0))
 
         # Select files button
         self.select_files_btn = self._styled_btn(
@@ -361,12 +725,145 @@ class PDFMergerApp:
         self.file_listbox.pack(side="left", fill="both", expand=True, padx=8, pady=4)
         scrollbar.config(command=self.file_listbox.yview)
 
+        # ── Split options ────────────────────────────────────────────────────
+        self.split_options_card = tk.Frame(
+            body,
+            bg=THEME["surface"],
+            highlightbackground=THEME["border"],
+            highlightthickness=1,
+        )
+        self.split_options_card.pack(fill="x", pady=(12, 0))
+
+        split_inner = tk.Frame(self.split_options_card, bg=THEME["surface"])
+        split_inner.pack(fill="x", padx=12, pady=10)
+
+        self.split_method_label = tk.Label(
+            split_inner,
+            text=self.t["split_method"],
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            font=self.font_label,
+        )
+        self.split_method_label.grid(row=0, column=0, sticky="w")
+
+        methods_row = tk.Frame(split_inner, bg=THEME["surface"])
+        methods_row.grid(row=1, column=0, sticky="w", pady=(6, 0))
+
+        self.split_range_rb = tk.Radiobutton(
+            methods_row,
+            text=self.t["split_by_ranges"],
+            variable=self.split_mode_var,
+            value="range",
+            command=self._on_split_mode_change,
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            selectcolor=THEME["surface"],
+            activebackground=THEME["surface"],
+            activeforeground=THEME["text"],
+            font=self.font_btn_sm,
+            padx=6,
+            highlightthickness=0,
+        )
+        self.split_range_rb.pack(side="left", padx=(0, 8))
+
+        self.split_every_n_rb = tk.Radiobutton(
+            methods_row,
+            text=self.t["split_every_n"],
+            variable=self.split_mode_var,
+            value="every_n",
+            command=self._on_split_mode_change,
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            selectcolor=THEME["surface"],
+            activebackground=THEME["surface"],
+            activeforeground=THEME["text"],
+            font=self.font_btn_sm,
+            padx=6,
+            highlightthickness=0,
+        )
+        self.split_every_n_rb.pack(side="left", padx=(0, 8))
+
+        self.split_bookmarks_rb = tk.Radiobutton(
+            methods_row,
+            text=self.t["split_by_bookmarks"],
+            variable=self.split_mode_var,
+            value="bookmarks",
+            command=self._on_split_mode_change,
+            bg=THEME["surface"],
+            fg=THEME["text"],
+            selectcolor=THEME["surface"],
+            activebackground=THEME["surface"],
+            activeforeground=THEME["text"],
+            font=self.font_btn_sm,
+            padx=6,
+            highlightthickness=0,
+        )
+        self.split_bookmarks_rb.pack(side="left")
+
+        self.ranges_label = tk.Label(
+            split_inner,
+            text=self.t["ranges_label"],
+            bg=THEME["surface"],
+            fg=THEME["text_secondary"],
+            font=self.font_status,
+        )
+        self.ranges_label.grid(row=2, column=0, sticky="w", pady=(10, 3))
+
+        self.ranges_entry = tk.Entry(
+            split_inner,
+            textvariable=self.split_ranges_var,
+            bg=THEME["entry_bg"],
+            fg=THEME["text"],
+            relief="flat",
+            borderwidth=1,
+            highlightthickness=1,
+            highlightbackground=THEME["border"],
+            font=self.font_label,
+            insertbackground=THEME["text"],
+        )
+        self.ranges_entry.grid(row=3, column=0, sticky="ew")
+
+        self.every_n_label = tk.Label(
+            split_inner,
+            text=self.t["every_n_label"],
+            bg=THEME["surface"],
+            fg=THEME["text_secondary"],
+            font=self.font_status,
+        )
+        self.every_n_label.grid(row=4, column=0, sticky="w", pady=(10, 3))
+
+        self.every_n_entry = tk.Entry(
+            split_inner,
+            textvariable=self.split_every_n_var,
+            bg=THEME["entry_bg"],
+            fg=THEME["text"],
+            relief="flat",
+            borderwidth=1,
+            highlightthickness=1,
+            highlightbackground=THEME["border"],
+            font=self.font_label,
+            insertbackground=THEME["text"],
+            width=10,
+        )
+        self.every_n_entry.grid(row=5, column=0, sticky="w")
+
+        self.split_hint_label = tk.Label(
+            split_inner,
+            text=self.t["split_hint_ranges"],
+            bg=THEME["surface"],
+            fg=THEME["text_secondary"],
+            font=self.font_status,
+        )
+        self.split_hint_label.grid(row=6, column=0, sticky="w", pady=(10, 0))
+
+        split_inner.grid_columnconfigure(0, weight=1)
+
         # ── Output name ──────────────────────────────────────────────────────
-        output_section = tk.Frame(body, bg=THEME["bg"])
-        output_section.pack(fill="x", pady=(12, 0))
+        self.output_section = tk.Frame(body, bg=THEME["bg"])
+        self.output_section.pack(fill="x", pady=(12, 0))
 
         self.output_name_label = tk.Label(
-            output_section,
+            self.output_section,
             text=self.t["output_name"],
             bg=THEME["bg"],
             fg=THEME["text"],
@@ -375,7 +872,7 @@ class PDFMergerApp:
         self.output_name_label.pack(anchor="w", pady=(0, 5))
 
         self._entry_frame = tk.Frame(
-            output_section,
+            self.output_section,
             bg=THEME["entry_bg"],
             highlightbackground=THEME["border"],
             highlightthickness=1,
@@ -406,15 +903,15 @@ class PDFMergerApp:
             ),
         )
 
-        # ── Merge button ─────────────────────────────────────────────────────
-        self.merge_pdfs_btn = self._styled_btn(
+        # ── Primary action button ───────────────────────────────────────────
+        self.run_action_btn = self._styled_btn(
             body,
             text=self.t["merge_pdfs"],
-            command=self._merge_pdfs,
+            command=self._run_action,
             bg=THEME["primary"],
             hover_bg=THEME["primary_hover"],
         )
-        self.merge_pdfs_btn.pack(fill="x", pady=(12, 0))
+        self.run_action_btn.pack(fill="x", pady=(12, 0))
 
         # ── Status bar ───────────────────────────────────────────────────────
         self._hairline(root).pack(fill="x")
@@ -444,6 +941,8 @@ class PDFMergerApp:
         self.destination_label.pack(side="left", padx=(4, 0))
 
         self._update_lang_buttons()
+        self._update_mode_ui()
+        self._on_split_mode_change()
 
     # ── Internal helpers ───────────────────────────────────────────────────
 
@@ -480,6 +979,32 @@ class PDFMergerApp:
         for path in self._pdf_paths:
             self.file_listbox.insert(tk.END, f"  {Path(path).name}")
 
+    def _update_mode_ui(self) -> None:
+        merge_mode = self.operation == "merge"
+        self.subtitle_label.config(
+            text=self.t["app_subtitle_merge"] if merge_mode else self.t["app_subtitle_split"]
+        )
+        self.select_files_btn.config(
+            text=self.t["select_files"] if merge_mode else self.t["select_single_file"]
+        )
+        self.output_name_label.config(
+            text=self.t["output_name"] if merge_mode else self.t["output_prefix"]
+        )
+        self.run_action_btn.config(
+            text=self.t["merge_pdfs"] if merge_mode else self.t["split_pdfs"]
+        )
+
+        if merge_mode:
+            self.move_up_btn.config(state="normal")
+            self.move_down_btn.config(state="normal")
+            if self.split_options_card.winfo_ismapped():
+                self.split_options_card.pack_forget()
+        else:
+            self.move_up_btn.config(state="disabled")
+            self.move_down_btn.config(state="disabled")
+            if not self.split_options_card.winfo_ismapped():
+                self.split_options_card.pack(fill="x", pady=(12, 0), before=self.output_section)
+
     # ── Event handlers ─────────────────────────────────────────────────────
 
     def _set_language(self, lang: str) -> None:
@@ -487,26 +1012,73 @@ class PDFMergerApp:
         self._on_language_change()
 
     def _on_language_change(self) -> None:
-        self.subtitle_label.config(text=self.t["app_subtitle"])
-        self.select_files_btn.config(text=self.t["select_files"])
-        self.merge_pdfs_btn.config(text=self.t["merge_pdfs"])
+        self.title_label.config(text=self.t["app_title"])
+        self.language_label.config(text=self.t["language_label"])
+        self.operation_label.config(text=self.t["operation_label"])
+        self.mode_merge_rb.config(text=self.t["mode_merge"])
+        self.mode_split_rb.config(text=self.t["mode_split"])
         self.move_up_btn.config(text=self.t["move_up"])
         self.move_down_btn.config(text=self.t["move_down"])
-        self.output_name_label.config(text=self.t["output_name"])
         self.remove_pdf_btn.config(text=self.t["remove_pdf"])
         self._dest_key_label.config(text=self.t["destination"])
+
+        self.split_method_label.config(text=self.t["split_method"])
+        self.split_range_rb.config(text=self.t["split_by_ranges"])
+        self.split_every_n_rb.config(text=self.t["split_every_n"])
+        self.split_bookmarks_rb.config(text=self.t["split_by_bookmarks"])
+        self.ranges_label.config(text=self.t["ranges_label"])
+        self.every_n_label.config(text=self.t["every_n_label"])
+
         self._update_lang_buttons()
+        self._update_mode_ui()
+        self._on_split_mode_change()
         self._update_file_count()
 
+    def _on_operation_change(self) -> None:
+        self._update_mode_ui()
+        # Keep split workflow strict to one source file.
+        if self.operation == "split" and len(self._pdf_paths) > 1:
+            self._pdf_paths = self._pdf_paths[:1]
+            self._refresh_listbox()
+            self._update_file_count()
+
+    def _on_split_mode_change(self) -> None:
+        mode = self.split_mode
+        if mode == "range":
+            self.ranges_entry.config(state="normal")
+            self.every_n_entry.config(state="disabled")
+            self.split_hint_label.config(text=self.t["split_hint_ranges"])
+        elif mode == "every_n":
+            self.ranges_entry.config(state="disabled")
+            self.every_n_entry.config(state="normal")
+            self.split_hint_label.config(text=self.t["split_hint_every_n"])
+        else:
+            self.ranges_entry.config(state="disabled")
+            self.every_n_entry.config(state="disabled")
+            self.split_hint_label.config(text=self.t["split_hint_bookmarks"])
+
     def _select_files(self) -> None:
-        pdf_files = filedialog.askopenfilenames(filetypes=[("PDF files", "*.pdf")])
-        if not pdf_files:
-            return  # user cancelled the dialog
-        self.folder_var.set(str(Path(pdf_files[0]).parent))
-        self._pdf_paths = list(pdf_files)
+        if self.operation == "merge":
+            selected = filedialog.askopenfilenames(filetypes=[("PDF files", "*.pdf")])
+            if not selected:
+                return
+            self._pdf_paths = list(selected)
+        else:
+            selected = filedialog.askopenfilename(filetypes=[("PDF files", "*.pdf")])
+            if not selected:
+                return
+            self._pdf_paths = [selected]
+
+        self.folder_var.set(str(Path(self._pdf_paths[0]).parent))
         self._refresh_listbox()
         self._update_file_count()
         self.destination_label.config(text=self.folder_var.get())
+
+    def _run_action(self) -> None:
+        if self.operation == "merge":
+            self._merge_pdfs()
+        else:
+            self._split_pdf()
 
     def _merge_pdfs(self) -> None:
         destination = self.folder_var.get()
@@ -540,8 +1112,9 @@ class PDFMergerApp:
         except FileExistsError:
             messagebox.showerror("Error", self.t["file_exists"])
             return
-        except ValueError:
-            messagebox.showerror("Error", self.t["no_valid_pdfs"])
+        except ValueError as exc:
+            key = str(exc)
+            messagebox.showerror("Error", self.t.get(key, self.t["no_valid_pdfs"]))
             return
         except OSError as exc:
             messagebox.showerror("Error", str(exc))
@@ -554,6 +1127,54 @@ class PDFMergerApp:
         messagebox.showinfo(
             "Success",
             self.t["operation_completed"].format(destination, pdfname),
+        )
+
+    def _split_pdf(self) -> None:
+        files = self._pdf_paths
+        destination = self.folder_var.get()
+
+        if len(files) != 1:
+            messagebox.showerror("Error", self.t["split_requires_one_pdf"])
+            return
+        if not destination:
+            messagebox.showerror("Error", self.t["no_destination"])
+            return
+
+        source_pdf = files[0]
+        source_stem = Path(source_pdf).stem
+        output_stem = PDF.build_output_stem(self.output_name_var.get(), source_stem)
+        output_dir = Path(destination)
+
+        try:
+            if self.split_mode == "range":
+                created = PDF.split_by_ranges(
+                    source_pdf,
+                    output_dir,
+                    output_stem,
+                    self.split_ranges_var.get(),
+                )
+            elif self.split_mode == "every_n":
+                try:
+                    chunk_size = int(self.split_every_n_var.get().strip())
+                except ValueError:
+                    raise ValueError("invalid_chunk_size") from None
+                created = PDF.split_every_n(source_pdf, output_dir, output_stem, chunk_size)
+            else:
+                created = PDF.split_by_bookmarks(source_pdf, output_dir, output_stem)
+        except FileExistsError as exc:
+            messagebox.showerror("Error", self.t["split_file_exists"].format(Path(str(exc)).name))
+            return
+        except ValueError as exc:
+            key = str(exc)
+            messagebox.showerror("Error", self.t.get(key, key))
+            return
+        except OSError as exc:
+            messagebox.showerror("Error", str(exc))
+            return
+
+        messagebox.showinfo(
+            "Success",
+            self.t["split_completed"].format(len(created), destination),
         )
 
     def _move_up(self) -> None:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # PyPDFMerger
 
-A simple GUI application for merging multiple PDF files into one, built with Python and tkinter.
+A simple GUI application for merging multiple PDF files into one or splitting a PDF into multiple outputs, built with Python and tkinter.
 
 ## Features
 
-- Select and merge multiple PDF files into a single PDF
-- Reorder files before merging with Move Up / Move Down
-- Remove individual files from the selection
-- Automatic validation — invalid or unreadable PDFs are skipped with a warning
+- Merge mode:
+  - Select and merge multiple PDF files into a single PDF
+  - Reorder files before merging with Move Up / Move Down
+  - Remove individual files from the selection
+  - Automatic validation — invalid or unreadable PDFs are skipped with a warning
+- Split mode:
+  - Split one PDF by page ranges (for example: `1-3,5,8-10`)
+  - Split one PDF every N pages
+  - Split one PDF by top-level bookmarks/sections
 - English / Spanish language toggle
 
 ## Requirements


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add split workflow alongside existing merge flow via a mode switch in the UI
- implement split by page ranges, every N pages, and top-level bookmarks/sections
- keep merge behavior intact while adapting labels/buttons and controls by mode
- add validation and localized error/success feedback for split scenarios
- update README feature list to include split support

## Testing
- `python3 -m py_compile PyPDFMerger/PyPDFMergerGUI.pyw`
- headless smoke verification of real `PDF` class logic (merge + split by ranges + split every N + split by bookmarks) using temporary generated PDFs

## Notes
- split mode requires exactly one selected PDF
- output name field acts as an optional output prefix in split mode
- split operation fails fast if any target output file already exists
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf8cb701-4f5e-403a-8015-8d85c3306e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf8cb701-4f5e-403a-8015-8d85c3306e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

