### PR TITLE
Improve missing pypdf guidance for direct Windows launch

### DIFF
--- a/PyPDFMerger/PyPDFMergerGUI.pyw
+++ b/PyPDFMerger/PyPDFMergerGUI.pyw
@@ -10,10 +10,34 @@ import threading
 from typing import Callable
 from urllib.parse import unquote, urlparse
 
-import pypdf
 import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog, ttk
 from tkinter import font as tkfont
+
+def _show_missing_dependency_error(package_name: str) -> None:
+    install_cmd = "python -m pip install -r requirements.txt"
+    message = (
+        f"Missing dependency: '{package_name}'.\n\n"
+        "Install the project dependencies and run again:\n"
+        f"{install_cmd}"
+    )
+    try:
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror("PyPDFMerger", message)
+        root.destroy()
+    except Exception:
+        # If Tk cannot initialize (headless env), still exit with the same message.
+        pass
+    raise SystemExit(message)
+
+
+try:
+    import pypdf
+except ModuleNotFoundError as exc:
+    if exc.name == "pypdf":
+        _show_missing_dependency_error("pypdf")
+    raise
 
 try:
     from tkinterdnd2 import DND_FILES, TkinterDnD

--- a/README.md
+++ b/README.md
@@ -48,14 +48,25 @@ A simple GUI application for merging multiple PDF files into one or splitting a 
 
 3. **Install dependencies**:
    ```sh
-   pip install -r requirements.txt
+   python -m pip install -r requirements.txt
    ```
+
+   If you see `ModuleNotFoundError: No module named 'pypdf'`, it means the
+   dependencies were not installed in the Python interpreter you are using to run
+   the app.
 
 ## Usage
 
 ### Run directly
 
 ```sh
+python PyPDFMerger/PyPDFMergerGUI.pyw
+```
+
+On Windows PowerShell, after activating your virtual environment, you can run:
+
+```powershell
+python -m pip install -r requirements.txt
 python PyPDFMerger/PyPDFMergerGUI.pyw
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add startup handling in `PyPDFMergerGUI.pyw` for a missing `pypdf` dependency
- show a GUI error dialog (when available) with the exact install command to run
- update README setup/usage examples to use `python -m pip` and explicitly mention the `pypdf` error case

## Testing
- `python3 -m py_compile PyPDFMerger/PyPDFMergerGUI.pyw`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b17bcffb-dfdf-420c-9191-f9af98e56516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b17bcffb-dfdf-420c-9191-f9af98e56516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

